### PR TITLE
Fix macOS SDL2 install instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ On **Ubuntu 14.04 and above**, run:
 
 On **MacOS** install SDL2 via Homebrew:
 
-`brew install sdl2{,-image,-mixer,-ttf}`
+`brew install sdl2{,_image,_mixer,_ttf}`
 
 On **Windows**,
 


### PR DESCRIPTION
This corrects the macOS (Homebrew) install instructions. Brew lists the packages with underscores rather than hyphens. Previously this command would fail when installing image, mixer, and ttf.